### PR TITLE
Added support for mChat

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -11,6 +11,7 @@ services:
         arguments:
             - '@config'
             - '@dbal.conn'
+            - '@?dmzx.mchat.settings'
 
     crizzo.ipanonym.cron.task.anonymise_ip:
         class: crizzo\ipanonym\cron\anonymise_ip


### PR DESCRIPTION
This PR adds mChat's `phpbb_mchat` and `phpbb_mchat_log` tables to the anonymisation process. Requires at least mChat 2.1.0.